### PR TITLE
Foreground handling cleanup

### DIFF
--- a/docs/notebooks/XFaster_Tutorial.ipynb
+++ b/docs/notebooks/XFaster_Tutorial.ipynb
@@ -13,7 +13,7 @@
    "source": [
     "This tutorial is also a Jupyter notebook, which can be found in [the example notebooks directory](https://github.com/annegambrel/xfaster/tree/main/example/notebooks). If you're running the notebook, rather than looking at the documentation produced from it, the links will not work. [Look at the docs for working links](https://annegambrel.github.io/xfaster/notebooks/XFaster_Tutorial.html).\n",
     "\n",
-    "The notebook reads intermediate output npz files from disk. To instead run the pieces starting from maps, first generate the example maps by running the script `xfaster/example/make_example_maps.py`, and set the checkpoint to something other than None."
+    "The notebook reads intermediate output npz files from disk. To instead run the pieces starting from maps, first generate the example maps by running the script `xfaster/example/make_example_maps.py`, and set the checkpoint to something other than `None`.  This script generates sample signal (CMB), noise and foreground ensembles for the two SPIDER frequency bands, as well as two sets of simulated data maps (one with signal, noise and foreground components; and one with just signal and noise components)."
    ]
   },
   {
@@ -419,7 +419,9 @@
     "\n",
     "Residuals are fit per map, and by default are fit only for EE and BB, which are constrained to have the same fit parameter. To change this, use the option `res_specs`, which takes a list of the spectra you want to fit residuals for, ie. `[\"TT\", \"EE\", \"BB\"]` if you'd like to fit all of the spectra separately.\n",
     "\n",
-    "The last option you might wish to use is `weighted_bins`, which changes the default $\\chi_b(\\ell)$ binning operator from a tophat to one that weights by $\\ell(\\ell+1)$."
+    "Another option you might wish to use is `weighted_bins`, which changes the default $\\chi_b(\\ell)$ binning operator from a tophat to one that weights by $\\ell(\\ell+1)$.\n",
+    "\n",
+    "To enable fitting for a foreground component in the harmonic domain, set `foreground_fit=True`, and use the corresponding `bin_width_fg` to set the bin width for the foreground amplitude bins.  Optionally, also set `beta_fit=True` to enable fitting for a frequency spectral index component for the foreground amplitude; otherwise, the frequency dependence is assumed to follow a single component dust model as defined in [scale_dust()](../api.rst#xfaster.spec_tools.scale_dust).  If `foreground_fit` is True, the foreground model is assumed to be a simple power law model, as defined in [dust_model()](../api.rst#xfaster.spec_tools.dust_model), with the same transfer function as the CMB component."
    ]
   },
   {
@@ -736,7 +738,9 @@
     "\n",
     "We have $K_{\\ell, \\ell'}$ and $B_{\\ell}$. For the transfer function calculation, we're going to set $F_\\ell$ to 1 so that we measure $q_b$s as the deviation from a uniform transfer function for our simulations. Binning, $\\chi_b$ has been chosen. All that's left is the full sky signal shape, $\\mathcal{C}_{\\ell'}^{XY (S)}$, loaded with [get_signal_shape()](../api.rst#xfaster.xfaster_class.XFaster.get_signal_shape). \n",
     "\n",
-    "For calculating the transfer function, this is just the shape spectrum that went into making our simulations. This spectrum can be specified by setting the argument `signal_transfer_spec` to a file containing the spectrum. If not provided, the code will look in the maps directory for the signal sims for a file labeled `spec_signal_<signal_type>.dat`. The file is expected to look like a CAMB output file, as demonstrated in `make_example_maps.py`, which writes such a file to the proper location in the signal sims directory."
+    "For calculating the transfer function, this is just the shape spectrum that went into making our simulations. This spectrum can be specified by setting the [xfaster_run()](../api.rst#xfaster.xfaster_exec.xfaster_run) argument `signal_transfer_spec` to a file containing the spectrum for the signal component. If not provided, the code will look in the maps directory for the signal sims for a file labeled `spec_signal_<signal_type>.dat`. The file is expected to look like a CAMB output file, as demonstrated in `make_example_maps.py`, which writes such a file to the proper location in the signal sims directory.\n",
+    "\n",
+    "For foreground fitting, this function also applies a frequency-dependent scaling to the input signal shape, using the [scale_dust()](../api.rst#xfaster.spec_tools.scale_dust) function.  The arguments `freq_ref` and `beta_ref` are used to set the reference frequency and spectral index for the scaling function."
    ]
   },
   {
@@ -1102,7 +1106,7 @@
     "from collections import OrderedDict\n",
     "# construct a dummy qb array to compute input model\n",
     "qb = OrderedDict([(k, np.ones(len(v))) for k, v in X.bin_def.items()])\n",
-    "cls_model = X.get_model_spectra(qb, cbl, delta=True, cls_noise=X.cls_noise, cond_noise=1e-5)\n",
+    "cls_model = X.get_model_spectra(qb, cbl, cls_noise=X.cls_noise, cond_noise=1e-5)\n",
     "\n",
     "fig, axs = plt.subplots(2, 3, figsize=(11,7))\n",
     "axs = axs.ravel()\n",

--- a/example/make_example_maps.py
+++ b/example/make_example_maps.py
@@ -8,26 +8,32 @@ This scipt will generate the ensemble of maps needed to run the
 xfaster_example.py script, including fake data maps, signal sims,
 noise sims, and masks.
 
-Script should take <10 minutes and write about 240 M of maps to disk
+Script should take <10 minutes and write about 350 M of maps to disk
 """
 
 # set up options
 nsim = 100
 nside = 256
-seed0 = 0
-np.random.seed(seed0)
+do_fg = True
+
+betad = 1.54
+ref_freq = 359.7
 
 tags = [95, 150]
+freqs = [94.7, 151.0]
+scales = [xf.spec_tools.scale_dust(f, nu0=ref_freq, beta=betad) for f in freqs]
 fwhms = [41.0, 29.0]  # arcmin
 gnoise = [4.5, 3.5]  # Temp std, uK_CMB
 data_noise_scale = 0.85  # make data noise less than sims by 15%
 
 mask_path = "maps_example/masks_rectangle"
 data_path = "maps_example/data_raw/full"
+data_fg_path = "maps_example/data_cmbfg/full"
 sig_path = "maps_example/signal_synfast/full"
 noise_path = "maps_example/noise_gaussian/full"
+fg_path = "maps_example/foreground_gaussian/full"
 
-for p0 in [mask_path, data_path, sig_path, noise_path]:
+for p0 in [mask_path, data_path, data_fg_path, sig_path, noise_path, fg_path]:
     if not os.path.exists(p0):
         os.makedirs(p0)
 
@@ -39,83 +45,145 @@ lfac = ell * (ell + 1) / (2 * np.pi)
 # spectrum for signal sims-- synfast expects Cls
 spec_file = os.path.join(*sig_path.split("/")[:-1], "spec_signal_synfast.dat")
 if os.path.exists(spec_file):
-    dls = np.loadtxt(spec_file, unpack=True)[1:]
-    cls = np.hstack([np.zeros((len(dls), 2)), dls / lfac[2:]])
+    cls = xf.spec_tools.load_camb_cl(spec_file, lfac=False)
 else:
     cls = xf.get_camb_cl(r=1.0, lmax=2000, lfac=False)
     # write to disk for transfer function
     dls = np.vstack([ell[2:], (lfac * cls)[:, 2:]])
     np.savetxt(spec_file, dls.T)
 
+# spectrum for foreground sims
+fg_spec_file = os.path.join(*fg_path.split("/")[:-1], "spec_foreground_gaussian.dat")
+if os.path.exists(spec_file):
+    cls_fg = xf.spec_tools.load_camb_cl(spec_file, lfac=False)
+else:
+    cls_fg = xf.spec_tools.dust_model(ell, lfac=False)
+    # write to disk for transfer function
+    dls_fg = np.vstack([ell[2:], (lfac * cls_fg)[:, 2:]])
+    np.savetxt(fg_spec_file, dls_fg.T)
+
 # load a filter transfer function to smooth by
 fl = np.loadtxt("maps_example/transfer_example.txt")
+mask = None
+
+
+def read_map(filename, fill=None):
+    fields = 0 if "mask" in filename else (0, 1, 2)
+    data = np.asarray(hp.read_map(filename, field=fields))
+    if fill is not None:
+        data[hp.mask_bad(data)] = fill
+    return data
+
+
+def write_map(filename, data, mask=None):
+    if mask is not None:
+        data[..., ~mask] = hp.UNSEEN
+    hp.write_map(filename, data, partial=True, overwrite=True)
+
+
+mask = None
+mask_write = None
 
 # make celestial rectangular coordinate mask
-latrange = [-55, -15]
-lonrange = [18, 80]
-theta, phi = hp.pix2ang(nside, np.arange(hp.nside2npix(nside)))
-lat = 90 - np.rad2deg(theta)
-lon = np.rad2deg(phi)
-lon[lon > 180] -= 360
-mask = np.logical_and(
-    np.logical_and(lon > lonrange[0], lon < lonrange[1]),
-    np.logical_and(lat > latrange[0], lat < latrange[1]),
-)
-mask_write = mask.copy().astype(float)
-mask_write[~mask] = hp.UNSEEN  # to reduce size of file on disk
-# Because using polarization, need I/Q/U mask
-mask_write = np.tile(mask_write, [3, 1])
 for tag in tags:
-    hp.write_map(
-        os.path.join(mask_path, "mask_map_{}.fits".format(tag)),
-        mask_write,
-        partial=True,
-        overwrite=True,
-    )
+    mask_file = os.path.join(mask_path, "mask_map_{}.fits".format(tag))
+    if os.path.exists(mask_file):
+        mask = read_map(mask_file, fill=0).astype(bool)
+        break
+
+    if mask is None:
+        latrange = [-55, -15]
+        lonrange = [18, 80]
+        theta, phi = hp.pix2ang(nside, np.arange(hp.nside2npix(nside)))
+        lat = 90 - np.rad2deg(theta)
+        lon = np.rad2deg(phi)
+        lon[lon > 180] -= 360
+        mask = np.logical_and(
+            np.logical_and(lon > lonrange[0], lon < lonrange[1]),
+            np.logical_and(lat > latrange[0], lat < latrange[1]),
+        )
+        mask_write = mask.copy().astype(float)
+        mask_write[~mask] = hp.UNSEEN  # to reduce size of file on disk
+        # Because using polarization, need I/Q/U mask
+        mask_write = np.tile(mask_write, [3, 1])
+
+    write_map(mask_file, mask_write)
     print("Wrote mask map {}".format(tag))
 
-# make data, signal, noise sims
-for i in range(nsim + 1):
-    sig = hp.synfast(cls, nside=nside, new=True, pixwin=True)
-    noise = np.zeros_like(sig)
+sig_cache = {}
+fg_cache = {}
 
-    # smooth both by filter transfer function
-    sig = hp.smoothing(sig, beam_window=np.sqrt(fl))
+
+def sim_signal(isim, itag):
+    if isim not in sig_cache:
+        np.random.seed(isim)
+        sig = hp.synfast(cls, nside=nside, new=True, pixwin=True)
+        sig = hp.smoothing(sig, beam_window=np.sqrt(fl))
+        sig_cache[isim] = np.asarray(sig)
+    return hp.smoothing(sig_cache[isim], np.deg2rad(fwhms[itag] / 60.0), verbose=False)
+
+
+def sim_noise(isim, itag):
+    np.random.seed(nsim * (1 + itag) + isim)
+    noise = np.tile((3, 1), np.zeros(mask.size, dtype=float))
+    noise[0][mask] = np.random.normal(scale=gnoise[itag], size=np.sum(mask))
+    noise[1][mask] = np.random.normal(
+        scale=gnoise[itag] * np.sqrt(2), size=np.sum(mask)  # pol
+    )
+    noise[2][mask] = np.random.normal(
+        scale=gnoise[itag] * np.sqrt(2), size=np.sum(mask)  # pol
+    )
+    return hp.smoothing(noise, beam_window=np.sqrt(fl))
+
+
+def sim_fg(isim, itag):
+    if isim not in fg_cache:
+        np.random.seed(nsim * (1 + len(tags)) + isim)
+        fg = hp.synfast(cls_fg, nside=nside, new=True, pixwin=True)
+        fg = hp.smoothing(fg, beam_window=np.sqrt(fl))
+        fg_cache[isim] = np.asarray(fg)
+    return scales[itag] * hp.smoothing(
+        fg_cache[isim], np.deg2rad(fwhms[itag] / 60.0), verbose=False
+    )
+
+
+# make data, signal, noise, fg sims
+for i in range(nsim + 1):
     for ti, tag in enumerate(tags):
-        sig_smooth = hp.smoothing(sig, np.deg2rad(fwhms[ti] / 60.0), verbose=False)
-        noise[0][mask] = np.random.normal(scale=gnoise[ti], size=np.sum(mask))
-        noise[1][mask] = np.random.normal(
-            scale=gnoise[ti] * np.sqrt(2), size=np.sum(mask)  # pol
-        )
-        noise[2][mask] = np.random.normal(
-            scale=gnoise[ti] * np.sqrt(2), size=np.sum(mask)  # pol
-        )
-        noise_smooth = hp.smoothing(noise, beam_window=np.sqrt(fl))
         if i == 0:
-            # call this data
-            dat = sig_smooth + data_noise_scale * noise_smooth
-            dat[:, ~mask] = hp.UNSEEN
-            hp.write_map(
-                os.path.join(data_path, "map_{}.fits".format(tag)),
-                dat,
-                partial=True,
-                overwrite=True,
-            )
-            print("Wrote data map {}".format(tag))
+            data_file = os.path.join(data_path, "map_{}.fits".format(tag))
+            data_fg_file = os.path.join(data_fg_path, "map_{}.fits".format(tag))
+            data = None
+            if not os.path.exists(data_file):
+                data = sim_sig(i, ti) + data_noise_scale * sim_noise(i, ti)
+                write_map(data_file, data, mask)
+                print("Wrote data signal+noise map {}".format(tag))
+            if do_fg and not os.path.exists(data_fg_file):
+                if data is None:
+                    data = read_map(data_file)
+                write_map(data_fg_file, data + sim_fg(i, ti), mask)
+                print("Wrote data signal+noise+fg map {}".format(tag))
         else:
-            # signal and noise
-            sig_smooth[:, ~mask] = hp.UNSEEN
-            noise_smooth[:, ~mask] = hp.UNSEEN
-            hp.write_map(
-                os.path.join(sig_path, "map_{}_{:04}.fits".format(tag, i - 1)),
-                sig_smooth,
-                partial=True,
-                overwrite=True,
+            sig_file = os.path.join(sig_path, "map_{}_{:04}.fits".format(tag, i - 1))
+            noise_file = os.path.join(
+                noise_path, "map_{}_{:04}.fits".format(tag, i - 1)
             )
-            hp.write_map(
-                os.path.join(noise_path, "map_{}_{:04}.fits".format(tag, i - 1)),
-                noise_smooth,
-                partial=True,
-                overwrite=True,
-            )
-            print("Wrote signal and noise map {} {} / {}".format(tag, i - 1, nsim))
+            fg_file = os.path.join(fg_path, "map_{}_{:04}.fits".format(tag, i - 1))
+
+            comps = []
+            if not os.path.exists(sig_file):
+                write_map(sig_file, sim_sig(i, ti), mask)
+                comps += ["sig"]
+            if not os.path.exists(noise_file):
+                write_map(noise_file, sim_noise(i, ti), mask)
+                comps += ["noise"]
+            if do_fg and not os.path.exists(fg_file):
+                write_map(fg_file, sim_fg(i, ti), mask)
+                comps += ["fg"]
+            if len(comps):
+                print(
+                    "Wrote {} map {} {} / {}".format(", ".join(comps), tag, i - 1, nsim)
+                )
+
+    sig_cache.pop(i, None)
+    fg_cache.pop(i, None)

--- a/example/xfaster_example_fg.py
+++ b/example/xfaster_example_fg.py
@@ -1,0 +1,67 @@
+import xfaster as xf
+
+# use this script to run the xfaster algorithm with your own options
+# like the example below
+
+submit = False  # submit to queue
+submit_opts = {
+    "wallt": 5,
+    "mem": 3,
+    "ppn": 1,
+    "omp_threads": 1,
+}
+
+# Paths for the following keys are relative to where this script is run:
+#     config, data_root, data_root2, output_root
+# If running this script from a different directory, make sure these
+# keys point to the correct locations.
+
+xfaster_opts = {
+    # run options
+    "pol": True,
+    "pol_mask": True,
+    "bin_width": 25,
+    "lmax": 500,
+    "multi_map": True,
+    "likelihood": False,
+    "output_root": "outputs_example_fg",
+    "output_tag": "95x150",
+    # input files
+    "config": "config_example.ini",
+    "data_root": "maps_example",
+    "data_subset": "full/*95,full/*150",
+    "data_type": "cmbfg",
+    "noise_type": "gaussian",
+    "mask_type": "rectangle",
+    "signal_type": "synfast",
+    "data_root2": None,
+    "data_subset2": None,
+    # residual fitting
+    "residual_fit": True,
+    "bin_width_res": 100,
+    # foreground fitting
+    "foreground_fit": True,
+    "beta_fit": False,
+    "bin_width_fg": 40,
+    "beta_ref": 1.54,
+    "freq_ref": 359.7,
+    # spectrum
+    "ensemble_mean": False,
+    "tbeb": True,
+    "converge_criteria": 0.005,
+    "iter_max": 200,
+    "save_iters": False,
+    # likelihood
+    "like_lmin": 26,
+    "like_lmax": 250,
+    # beams
+    "pixwin": True,
+    "verbose": "info",
+    "checkpoint": None,
+}
+
+if submit:
+    xfaster_opts.update(**submit_opts)
+    xf.xfaster_submit(**xfaster_opts)
+else:
+    xf.xfaster_run(**xfaster_opts)

--- a/xfaster/parse_tools.py
+++ b/xfaster/parse_tools.py
@@ -434,6 +434,9 @@ def load_and_parse(filename, check_version=True):
 
     if version in [1, 2]:
 
+        if "ref_freq" in data:
+            data["freq_ref"] = data.pop("ref_freq")
+
         if "map_files" in data:
             data["map_names"] = np.asarray(
                 [os.path.relpath(f, data["map_root"]) for f in data["map_files"]]

--- a/xfaster/spec_tools.py
+++ b/xfaster/spec_tools.py
@@ -2,117 +2,168 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
 import numpy as np
+import warnings
 
 __all__ = [
     "wigner3j",
     "get_camb_cl",
+    "load_camb_cl",
     "scale_dust",
+    "dust_model",
 ]
 
+k = 1.38064852e-23  # Boltzmann constant
+h = 6.626070040e-34  # Planck constant
+hk = h / k * 1.0e9  # conversion from GHz / K to unitless value
+T_dust = 19.6  # dust temperature in K
+T_cmb = 2.72548  # CMB blackbody temperature in K
 
-def blackbody(nu, ref_freq=353.0):
+
+def blackbody(nu, nu0=None, T=T_cmb):
     """
-    The ratio of the blackbody function for dust at frequency nu
-    over the value for reference frequency ref_freq
+    The blackbody function at temperature ``T`` and frequency ``nu``, optionally
+    relative to the value at reference frequency ``nu0``.
 
     Arguments
     ---------
     nu : float
         Frequency in GHz.
-    ref_freq : float
-        Reference frequency in GHz.
+    nu0 : float
+        Reference frequency in GHz.  If not supplied, return unreferenced
+        blackbody.
+    T : float
+        Blackbody temperature.
 
     Returns
     -------
-    blackbody_ratio : float
-        B(nu, T_dust) / B(nu_ref, T_dust)
+    blackbody : float
+        B(nu, T) / B(nu0, T)
     """
-    k = 1.38064852e-23  # Boltzmann constant
-    h = 6.626070040e-34  # Planck constant
-    T = 19.6
-    nu_ref = ref_freq * 1.0e9
-    nu *= 1.0e9  # GHz -> Hz
-    x = h * nu / k / T
-    x_ref = h * nu_ref / k / T
-    return x ** 3 / x_ref ** 3 * (np.exp(x_ref) - 1) / (np.exp(x) - 1)
+    x = hk * nu / T
+    if nu0 is None:
+        return x ** 3 / (np.exp(x) - 1)
+    x0 = hk * nu0 / T
+    return (x / x0) ** 3 * (np.exp(x0) - 1) / (np.exp(x) - 1)
 
 
-def rj2cmb(nu_in):
+def rj2bb(nu, nu0=None, T=T_cmb):
     """
-    Conversion from Rayleigh-Jeans units to CMB temperature units
+    Conversion from Rayleigh-Jeans units to Blackbody temperature units
 
     Arguments
     ---------
-    nu_in : float
+    nu : float
         Frequency in GHz.
+    nu0 : float
+        Reference frequency in GHz.  Ignored if not supplied.
+    T : float
+        Blakbody temperature
 
     Returns
     -------
     cal_fac : float
-        Number by which to multiply a RJ temperature to get a CMB temp
+        Value by which to multiply a RJ temperature to get a CMB temperature.
+        If ``nu0`` is given, return the value relative to that at the reference
+        frequency.
     """
-    k = 1.38064852e-23  # Boltzmann constant
-    h = 6.626070040e-34  # Planck constant
-    T = 2.72548  # Cmb BB temp in K
-    nu = nu_in * 1.0e9  # GHz -> Hz
-    x = h * nu / k / T
-    return (np.exp(x) - 1.0) ** 2 / (x ** 2 * np.exp(x))
+    x = hk * nu / T
+    if nu0 is None:
+        return ((np.exp(x) - 1.0) / x) ** 2 / np.exp(x)
+    x0 = hk * nu0 / T
+    return ((np.exp(x) - 1.0) / (np.exp(x0) - 1.0) * x0 / x) ** 2 * np.exp(x0 - x)
 
 
-def scale_dust(freq0, freq1, ref_freq, beta, delta_beta=None, deriv=False):
+def scale_dust(nu1, nu2=None, nu0=359.7, beta=1.54, delta=False):
     """
     Get the factor by which you must multiply the cross spectrum from maps of
-    frequencies freq0 and freq1 to match the dust power at ref_freq given
-    spectra index beta.
-
-    If deriv is True, return the frequency scaling at the reference beta,
-    and the first derivative w.r.t. beta.
-
-    Otherwise if delta_beta is given, return the scale factor adjusted
-    for a linearized offset delta_beta from the reference beta.
+    frequencies ``nu1`` and ``nu2`` to match the dust power at ``nu0`` given
+    spectral index ``beta``.  If ``nu2`` is not given, compute the map-domain
+    factor for ``nu1`` alone.  Optionally include terms to construct the
+    derivative with respect to ``beta`` if ``delta=True``.
 
     Arguments
     ---------
-    freq0 : float
+    nu1 : float
         Frequency of map0 in GHz.
-    freq1 : float
-        Frequency of map1 in GHz.
-    ref_freq : float
+    nu2 : float
+        Frequency of map1 in GHz.  If not supplied, return the map-domain
+        multiplicative factor for ``nu1`` only.
+    nu0 : float
         Reference frequency from which to compute relative scaling in GHz.
     beta : float
         Dust spectral index.
-    delta_beta : float
-        Difference from beta-- scaling computed as a first order Taylor
-        expansion from original beta-scaling.
-    deriv : bool
-        If true, return the frequency scaling at the reference beta, along with
-        the first derivative w.r.t. beta at the reference beta.
+    delta : bool
+        If True, also return the multiplicative beta scaling and its first
+        derivative.
 
     Returns
     -------
     freq_scale : float
-        The relative scaling factor for the dust cross spectrum-- multiply by
-        this number to get the dust spectrum at the reference frequency
-    -- or --
-    freq_scale, deriv : floats
-        The relative scaling factor and its derivative
+        The relative scaling factor for the dust map or spectrum-- multiply by
+        this number to get the dust map or spectrum at the reference frequency
+    beta_scale : float
+        The multiplicative scaling factor for beta-- multiply the
+        frequency-scaled map or spectrum by ``beta_scale ** delta_beta`` to
+        obtain the dust map or spectrum at the adjusted spectral index ``beta +
+        delta_beta``.
+    log_beta_scale : float
+        The first derivative of the ``beta`` scaling-- multiply the
+        frequency-scaled map or spectrum by this number to obtain the derivative
+        of the frequency-scaled map or spectrum with respect to ``beta``.
     """
-    freq_scale = (
-        rj2cmb(freq0)
-        * rj2cmb(freq1)
-        / rj2cmb(ref_freq) ** 2.0
-        * blackbody(freq0, ref_freq=ref_freq)
-        * blackbody(freq1, ref_freq=ref_freq)
-        * (freq0 * freq1 / ref_freq ** 2) ** (beta - 2.0)
+    bs = nu1 / nu0
+    fs = (
+        rj2bb(nu1, nu0=nu0, T=T_cmb)
+        * blackbody(nu1, nu0=nu0, T=T_dust)
+        * bs ** (beta - 2.0)
     )
 
-    if deriv or delta_beta is not None:
-        delta = np.log(freq0 * freq1 / ref_freq ** 2)
-        if deriv:
-            return (freq_scale, freq_scale * delta)
-        return freq_scale * (1 + delta * delta_beta)
+    if nu2 is None:
+        if delta:
+            return (fs, bs, np.log(bs))
+        return fs
 
-    return freq_scale
+    if delta:
+        fs2, bs2, log_bs2 = scale_dust(nu2, nu0=nu0, beta=beta, delta=True)
+        return (fs * fs2, bs * bs2, np.log(bs * bs2))
+
+    return fs * scale_dust(nu2, nu0=nu0, beta=beta, delta=False)
+
+
+def dust_model(ell, pivot=80, amp=34.0, index=-2.28, lfac=True):
+    """
+    Construct a power-law dust power spectrum.  Default parameter values are for
+    the Planck LIV best-fit EE dust spectrum.
+
+    The functional form is::
+
+        model = amp * (ell / pivot) ** index
+
+    Arguments
+    ---------
+    ell : array_like
+        Multipoles over which to compute the model
+    pivot : scalar
+        Pivot ell at which to refence the amplitude
+    amp : scalar
+        Model amplitude
+    index : scalar
+        Model spectral index
+    lfac: bool
+        If True, multiply Cls by ell*(ell+1)/2/pi
+
+    Returns
+    -------
+    model : array_like
+        The dust model computed for each input ell value.
+    """
+    ell = np.asarray(ell)
+    model = np.zeros(len(ell), dtype=float)
+    model[ell > 1] = amp * (ell[ell > 1] / float(pivot)) ** (index + 2.0)
+    if not lfac:
+        ellfac = ell * (ell + 1) / 2.0 / np.pi
+        model[ell > 1] /= ellfac[ell > 1]
+    return model
 
 
 def wigner3j(l2, m2, l3, m3):
@@ -179,7 +230,7 @@ def get_camb_cl(r, lmax, nt=None, spec="total", lfac=True):
     Returns
     -------
     cls : array_like
-        Array of spectra of shape (lmax + 1, nspec).
+        Array of spectra of shape (nspec, lmax + 1).
         Diagonal ordering (TT, EE, BB, TE).
     """
     # Set up a new set of parameters for CAMB
@@ -217,3 +268,79 @@ def get_camb_cl(r, lmax, nt=None, spec="total", lfac=True):
     totCL = powers[spec][: lmax + 1, :4].T
 
     return totCL
+
+
+def load_camb_cl(filename, lmax=None, pol=None, lfac=True):
+    """
+    Load a CAMB spectrum from a text file.  Expects a file with at
+    least two columns, where the first column contains ell values, and
+    the rest are spectrum components (TT, EE, BB, TE).  Old-style CAMB
+    files, where the spectra are ordered as (TT, TE, EE, BB), are
+    re-indexed into the new-style ordering.
+
+    Arguments
+    ---------
+    filename : str
+        Path to spectrum file on disk.
+    lmax : int
+        If supplied, return spectrum up to this ell.  Otherwise, all ell's are
+        included in the output.
+    pol : bool
+        If True, include polarization spectra in the output, if present in the
+        file.  If False, include only the TT spectrum.  Otherwise, include all
+        available spectra.
+    lfac : bool
+        If True, multiply Cls by ell*(ell+1)/2/pi
+
+    Returns
+    -------
+    cls : array_like
+        Array of spectra of shape (nspec, lmax + 1).
+        Diagonal ordering (TT, EE, BB, TE, EB, TB).
+    """
+
+    data = np.loadtxt(filename, unpack=True)
+    ell, data = data[0].astype(int), data[1:]
+
+    # limit to lmax
+    if lmax is not None:
+        if lmax > ell.max():
+            raise ValueError(
+                "Require at least lmax={} in CAMB file, found {}".format(
+                    lmax, ell.max()
+                )
+            )
+        idx = ell <= lmax
+        ell = ell[idx]
+        data = data[..., idx]
+
+    # include monopole and dipole
+    if ell.min() > 0:
+        n = ell.min()
+        ell = np.append(np.arange(n), ell)
+        data = np.append(np.zeros((len(data), n)), data, axis=1)
+
+    # check polarization
+    if pol is None:
+        pol = len(data) > 1
+
+    # select columns
+    if pol:
+        if len(data) == 1:
+            raise ValueError(
+                "Missing polarization spectra in CAMB file {}".format(filename)
+            )
+        if np.any(data[1, : ell.max() - 2] < 0):
+            warnings.warn("Old CAMB format file {}. Re-indexing.".format(filename))
+            order = [0, 2, 3, 1] if len(data) == 4 else [0, 3, 5, 1, 4, 2]
+            data = data[order, :]
+    else:
+        data = data[[0], :]
+
+    # check scaling
+    if not lfac:
+        f = ell * (ell + 1) / 2.0 / np.pi
+        f[ell == 0] = 1
+        data /= f[None, :]
+
+    return data

--- a/xfaster/xfaster_class.py
+++ b/xfaster/xfaster_class.py
@@ -3407,6 +3407,9 @@ class XFaster(object):
         r=None,
         component=None,
         flat=None,
+        filename_fg=None,
+        freq_ref=359.7,
+        beta_ref=1.54,
         signal_mask=None,
         transfer=False,
         save=True,
@@ -3428,28 +3431,40 @@ class XFaster(object):
         Arguments
         ---------
         filename : string
-            Filename for a spectrum on disk.  If None, and ``r`` is None and
-            ``flat`` is False, this will search for a spectrum stored in
-            ``signal_<signal_type>/spec_signal_<signal_type>.dat``.
-            Otherwise, if the filename is a relative path and not found,
-            the config directory is searched.
+            Filename for a signal spectrum on disk.  If None, and ``r`` is None
+            and ``flat`` is False, this will search for a spectrum stored in
+            ``signal_<signal_type>/spec_signal_<signal_type>.dat``.  Otherwise,
+            if the filename is a relative path and not found, the config
+            directory is searched.
         r : float
             If supplied and ``flat`` is False, a spectrum is computed using
             CAMB for the given ``r`` value.  Overrides ``filename``.
-        component : 'scalar', 'tensor', 'fg'
+        component : 'scalar', 'tensor', 'cmb', 'fg'
             If 'scalar', and ``r`` is not None, return just the r=0 scalar terms
             in the signal model.  If 'tensor', return just the tensor component
-            scaled by the input ``r`` value. If 'fg', return just fg term
+            scaled by the input ``r`` value. If 'cmb' or 'fg', return just those
+            signal terms.
         flat : float
             If given, a spectrum that is flat in ell^2 Cl is returned, with
             amplitude given by the supplied value. Overrides all other options.
+        filename_fg : string
+            Filename for a foreground spectrum on disk.  If the filename is a
+            relative path and not found, the config directory is searched.  If
+            not supplied, a power law dust model spectrum is assumed.
+        freq_ref : float
+            In GHz, reference frequency for dust model. Dust bandpowers output
+            will be at this reference frequency.
+        beta_ref : float
+            The spectral index of the dust model. This is a fixed value, with
+            an additive deviation from this value fit for in foreground fitting
+            mode.
         signal_mask: str array
             Include only these spectra, others set to zero.
             Options: TT, EE, BB, TE, EB, TB
         transfer : bool
             If True, this is a transfer function run. If ``filename`` is None
-            and ``r`` is None and ``flat`` is False, will search for a spectrum
-            stored in
+            and ``r`` is None and ``flat`` is False, will search for a signal
+            spectrum stored in
             ``signal_<signal_transfer_type>/spec_signal_<signal_transfer_type>.dat``.
         save : bool
             If True, save signal shape dict to disk.
@@ -3457,45 +3472,50 @@ class XFaster(object):
         Returns
         -------
         cls : OrderedDict
-            Dictionary keyed by spectrum (cmb_tt, cmb_ee, ... , fg), each
-            entry containing a vector of length 2 * lmax + 1
+            Dictionary keyed by spectrum (cmb_tt, cmb_ee, ... , fg_tt, ...),
+            each entry containing a vector of length 2 * lmax + 1.
         """
 
         lmax_kern = 2 * self.lmax
 
         specs = list(self.specs)
+
+        comps = list(self.signal_components)
+        if (self.null_run or transfer) and "fg" in comps:
+            comps.remove("fg")
+        if component in self.signal_components:
+            comps = [component]
+        elif component in ["scalar", "tensor"]:
+            comps = ["cmb"]
+
         if transfer:
             if "eb" in specs:
                 specs.remove("eb")
             if "tb" in specs:
                 specs.remove("tb")
         tbeb = "eb" in specs and "tb" in specs and r is None
-        specs = ["cmb_{}".format(spec) for spec in specs]
-
-        if not self.null_run and "fg_tt" in self.bin_def:
-            specs.append("fg")
-
-        if component == "fg":
-            specs = ["fg"]
-
-        nspecs = len(specs)
 
         if save:
-            shape = (nspecs, lmax_kern + 1)
+            shape = (len(specs) * len(comps), lmax_kern + 1)
             save_name = "shape_transfer" if transfer else "shape"
 
-            opts = dict(
-                filename=filename,
-                r=r,
-                flat=flat,
-                signal_mask=signal_mask,
-            )
+            opts = dict(signal_mask=signal_mask)
+            if "cmb" in comps:
+                opts.update(filename=filename, r=r, flat=flat)
+            if "fg" in comps:
+                opts.update(
+                    filename_fg=filename_fg, freq_ref=freq_ref, beta_ref=beta_ref
+                )
             ret = self.load_data(
                 save_name, save_name, shape_ref="cls_shape", shape=shape, value_ref=opts
             )
             if ret is not None:
-                if r is not None:
+                if "cmb" in comps and r is not None:
                     self.r_model = ret["r_model"]
+                if "fg" in comps:
+                    self.freq_ref = ret["freq_ref"]
+                    self.beta_ref = ret["beta_ref"]
+                    self.fg_scales = ret["fg_scales"]
                 self.cls_shape = ret["cls_shape"]
                 return ret["cls_shape"]
 
@@ -3503,101 +3523,113 @@ class XFaster(object):
         ellfac = ell * (ell + 1) / 2.0 / np.pi
         cls_shape = OrderedDict()
 
-        if flat is not None and flat is not False:
-            if flat is True:
-                flat = 2e-5
-            # flat spectrum for null tests
-            for spec in specs:
-                cls_shape[spec] = flat * np.ones_like(ell)
+        if "cmb" in comps:
+            if flat is not None and flat is not False:
+                if flat is True:
+                    flat = 2e-5
+                # flat spectrum for null tests
+                for spec in specs:
+                    cls_shape["cmb_" + spec] = flat * np.ones_like(ell)
 
-        elif r is not None:
-            # cache model components
-            if not hasattr(self, "r_model") or self.r_model is None:
-                # scalar CAMB spectrum
-                scal = st.get_camb_cl(r=0, lmax=lmax_kern)
-                # tensor CAMB spectrum for r=1, scales linearly with r
-                tens = st.get_camb_cl(r=1, lmax=lmax_kern, nt=0, spec="tensor")
-                self.r_model = {"scalar": scal, "tensor": tens}
-                if save:
-                    opts["r_model"] = self.r_model
-            # CAMB spectrum for given r value
-            component = str(component).lower()
-            if component == "scalar":
-                cls_camb = self.r_model["scalar"]
-            elif component == "tensor":
-                cls_camb = r * self.r_model["tensor"]
-            else:
-                cls_camb = self.r_model["scalar"] + r * self.r_model["tensor"]
-            ns, _ = cls_camb.shape
-            for s, spec in enumerate(specs[:ns]):
-                cls_shape[spec] = cls_camb[s]
-
-        elif any([x.startswith("cmb") for x in specs]):
-            # signal sim model or custom filename
-            if filename is None:
-                signal_root = (
-                    self.signal_transfer_root if transfer else self.signal_root
-                )
-                filename = "spec_{}.dat".format(os.path.basename(signal_root))
-                filename = os.path.join(signal_root, filename)
-            elif not os.path.exists(filename):
-                filename = os.path.join(self.config_root, filename)
-            if not os.path.exists(filename):
-                raise OSError("Missing model file {}".format(filename))
-
-            tmp = np.loadtxt(filename, unpack=True)
-
-            ltmp = tmp.shape[-1]
-            if lmax_kern + 1 < ltmp:
-                ltmp = lmax_kern + 1
-            else:
-                raise ValueError(
-                    "Require at least lmax={} in model file, found {}".format(
-                        lmax_kern, ltmp
-                    )
-                )
-
-            # camb starts at l=2, so set first 2 ells to be 0
-            cls_shape["cmb_tt"] = np.append([0, 0], tmp[1, : ltmp - 2])
-            if self.pol:
-                if np.any(tmp[2, : ltmp - 2] < 0):
-                    # this is true if TE is the third index instead of EE
-                    # (ell is 0th index for CAMB)
-                    self.warn(
-                        "Old CAMB format in model file {}. Re-indexing.".format(
-                            filename
-                        )
-                    )
-                    pol_specs = [3, 4, 2]
+            elif r is not None:
+                # cache model components
+                if not hasattr(self, "r_model") or self.r_model is None:
+                    # scalar CAMB spectrum
+                    scal = st.get_camb_cl(r=0, lmax=lmax_kern)
+                    # tensor CAMB spectrum for r=1, scales linearly with r
+                    tens = st.get_camb_cl(r=1, lmax=lmax_kern, nt=0, spec="tensor")
+                    self.r_model = {"scalar": scal, "tensor": tens}
+                    if save:
+                        opts["r_model"] = self.r_model
+                # CAMB spectrum for given r value
+                component = str(component).lower()
+                if component == "scalar":
+                    cls_camb = self.r_model["scalar"]
+                elif component == "tensor":
+                    cls_camb = r * self.r_model["tensor"]
                 else:
-                    pol_specs = [2, 3, 4]
-                for spec, d in zip(specs[1:4], tmp[pol_specs]):
-                    cls_shape[spec] = np.append([0, 0], d[: ltmp - 2])
+                    cls_camb = self.r_model["scalar"] + r * self.r_model["tensor"]
+                cls_shape.update({"cmb_" + s: cls for s, cls in zip(specs, cls_camb)})
 
-        # EB and TB flat l^2 * C_l
-        if self.pol:
-            if tbeb and (flat is None or flat is False):
-                tbeb_flat = np.abs(cls_shape["cmb_bb"][100]) * ellfac[100] * 1e-4
-                tbeb_flat = np.ones_like(cls_shape["cmb_bb"]) * tbeb_flat
-                tbeb_flat[:2] = 0
-                cls_shape["cmb_eb"] = np.copy(tbeb_flat)
-                cls_shape["cmb_tb"] = np.copy(tbeb_flat)
-            elif not tbeb and not transfer:
-                cls_shape["cmb_eb"] = np.zeros_like(ell, dtype=float)
-                cls_shape["cmb_tb"] = np.zeros_like(ell, dtype=float)
+            else:
+                # signal sim model or custom filename
+                if filename is None:
+                    signal_root = (
+                        self.signal_transfer_root if transfer else self.signal_root
+                    )
+                    filename = "spec_{}.dat".format(os.path.basename(signal_root))
+                    filename = os.path.join(signal_root, filename)
+                elif not os.path.exists(filename):
+                    filename = os.path.join(self.config_root, filename)
+                if not os.path.exists(filename):
+                    raise OSError("Missing model file {}".format(filename))
 
-        if "fg" in specs:
-            # From Planck LIV EE dust
-            cls_dust = 34.0 * (ell[2:] / 80.0) ** (-2.28 + 2.0)
-            cls_shape["fg"] = np.append([0, 0], cls_dust)
-            self.log(
-                "Added foreground to cls shape {}".format(list(cls_shape)), "debug"
-            )
+                cls_cmb = st.load_camb_cl(filename, lmax=lmax_kern, pol=self.pol)
+                cls_shape.update({"cmb_" + s: cls for s, cls in zip(specs, cls_cmb)})
+
+            # EB and TB flat l^2 * C_l
+            if self.pol:
+                if tbeb and (flat is None or flat is False):
+                    tbeb_flat = np.abs(cls_shape["cmb_bb"][100]) * ellfac[100] * 1e-4
+                    tbeb_flat = np.ones_like(cls_shape["cmb_bb"]) * tbeb_flat
+                    tbeb_flat[:2] = 0
+                    cls_shape["cmb_eb"] = np.copy(tbeb_flat)
+                    cls_shape["cmb_tb"] = np.copy(tbeb_flat)
+                elif not tbeb and not transfer:
+                    cls_shape["cmb_eb"] = np.zeros_like(ell, dtype=float)
+                    cls_shape["cmb_tb"] = np.zeros_like(ell, dtype=float)
+
+        if "fg" in comps:
+            # dust signal sim model or custom filename
+            # XXX optionally load freq_ref and beta_ref from file
+            if filename_fg is None:
+                # From Planck LIV EE dust
+                cls_dust = st.dust_model(ell, lfac=True)
+                for spec in specs:
+                    cls_shape["fg_" + spec] = cls_dust
+                self.log(
+                    "Added simple foregrounds to cls shape {}".format(list(cls_shape)),
+                    "debug",
+                )
+            else:
+                if not os.path.exists(filename_fg):
+                    filename_fg = os.path.join(self.config_root, filename_fg)
+                if not os.path.exists(filename_fg):
+                    raise OSError(
+                        "Missing foreground model file {}".format(filename_fg)
+                    )
+
+                cls_fg = st.load_camb_cl(filename_fg, lmax=lmax_kern, pol=None)
+                if len(cls_fg) == 1:
+                    cls_fg = np.tile(cls_fg, (len(specs), 1))
+                cls_shape.update({"fg_" + s: cls for s, cls in zip(specs, cls_fg)})
+
+            if self.pol and "fg_eb" not in cls_shape:
+                if tbeb:
+                    tbeb_flat = np.abs(cls_shape["fg_ee"][100]) * 1e-4
+                    tbeb_flat = np.ones_like(cls_shape["fg_ee"]) * tbeb_flat
+                    cls_shape["fg_eb"] = np.copy(tbeb_flat)
+                    cls_shape["fg_tb"] = np.copy(tbeb_flat)
+                else:
+                    cls_shape["fb_eb"] = np.zeros_like(ell, dtype=float)
+                    cls_shape["fb_tb"] = np.zeros_like(ell, dtype=float)
+
+            # frequency scaling for cross spectra
+            fg_scales = OrderedDict()
+            for xname, (m0, m1) in self.map_pairs.items():
+                f0 = self.map_freqs[m0]
+                f1 = self.map_freqs[m1]
+                fg_scales[xname] = st.scale_dust(f0, f1, freq_ref, beta_ref, delta=True)
+            self.fg_scales = fg_scales
+            self.freq_ref = freq_ref
+            self.beta_ref = beta_ref
+            if save:
+                opts["fg_scales"] = self.fg_scales
 
         # divide out l^2/2pi
-        for spec in specs:
-            cls_shape[spec][2:] /= ellfac[2:]
-            cls_shape[spec][:2] = 0.0
+        for cl in cls_shape.values():
+            cl[2:] /= ellfac[2:]
+            cl[:2] = 0.0
 
         if signal_mask is not None:
             self.log("Masking {} spectra".format(signal_mask), "debug")
@@ -3772,6 +3804,7 @@ class XFaster(object):
         res_specs=None,
         bin_width_res=25,
         foreground_fit=False,
+        beta_fit=False,
         bin_width_fg=25,
     ):
         """
@@ -3817,6 +3850,9 @@ class XFaster(object):
         foreground_fit : bool
             If True, construct bin definitions for foreground components as
             well.
+        beta_fit : bool
+            If True, include ``delta_beta`` in the foreground fitting parameters,
+            along with the foreground amplitudes.
         bin_width_fg : int or list of ints
             Width of each foreground spectrum bin.  If a scalar, the same width
             is applied to all cross spectra.  Otherwise, must be a list of up to
@@ -3855,6 +3891,9 @@ class XFaster(object):
         if self.pol and bin_width[1] != bin_width[2]:
             raise ValueError(bwerr)
 
+        comps = []
+        signal_comps = []
+
         # Define bins
         nbins_cmb = 0
         bin_def = OrderedDict()
@@ -3863,6 +3902,8 @@ class XFaster(object):
             bins = np.append(bins, self.lmax + 1)
             bin_def["cmb_{}".format(spec)] = np.column_stack((bins[:-1], bins[1:]))
             nbins_cmb += len(bins) - 1
+        comps += ["cmb"]
+        signal_comps += ["cmb"]
         self.log("Added {} CMB bins to bin_def".format(nbins_cmb), "debug")
 
         # Do the same for foreground bins
@@ -3880,9 +3921,13 @@ class XFaster(object):
                 bins = np.append(bins, self.lmax + 1)
                 bin_def["fg_{}".format(spec)] = np.column_stack((bins[:-1], bins[1:]))
                 nbins_fg += len(bins) - 1
-            bin_def["delta_beta"] = np.array([[0, 0]])
+            if beta_fit:
+                bin_def["delta_beta"] = np.array([[0, 0]])
+            comps += ["fg"]
+            signal_comps += ["fg"]
             self.log(
-                "Added {} foreground bins to bin_def".format(nbins_fg + 1), "debug"
+                "Added {} foreground bins to bin_def".format(nbins_fg + int(beta_fit)),
+                "debug",
             )
 
         # Do the same for residual bins
@@ -3911,6 +3956,7 @@ class XFaster(object):
                     bin_def[btag] = np.column_stack((bins[:-1], bins[1:]))
                     nbins_res += len(bins) - 1
 
+            comps += ["res"]
             self.log("Added {} residual bins to bin_def".format(nbins_res), "debug")
 
         ell = np.arange(self.lmax + 1)
@@ -3934,6 +3980,8 @@ class XFaster(object):
         self.specs = specs
         self.weighted_bins = weighted_bins
         self.bin_weights = bin_weights
+        self.components = comps
+        self.signal_components = signal_comps
 
         return self.bin_def
 
@@ -4098,11 +4146,12 @@ class XFaster(object):
         cbl = OrderedDict()
 
         comps = []
-        if "cmb_tt" in cls_shape or "cmb_ee" in cls_shape:
-            comps += ["cmb"]
-        if "fg" in cls_shape and not transfer_run:
-            comps += ["fg"]
-        if self.nbins_res > 0 and not transfer_run:
+        for comp in self.signal_components:
+            if any([k.startswith(comp + "_") for k in cls_shape]):
+                comps += [comp]
+        if "fg" in comps and transfer_run:
+            comps.remove("fg")
+        if "res" in self.components and not transfer_run:
             comps += ["res"]
             cls_noise = self.cls_noise_null if self.null_run else self.cls_noise
             cls_res = self.cls_res_null if self.null_run else self.cls_res
@@ -4178,11 +4227,12 @@ class XFaster(object):
                         continue
 
                     # use correct shape spectrum
+                    stag = "{}_{}".format(comp, spec)
                     if comp == "fg":
-                        # single foreground spectrum
-                        s_arr[xi] = cls_shape["fg"][lk]
+                        freq_scale = self.fg_scales[xname][0]
+                        s_arr[xi] = freq_scale * cls_shape[stag][lk]
                     else:
-                        s_arr[xi] = cls_shape["cmb_{}".format(spec)][lk]
+                        s_arr[xi] = cls_shape[stag][lk]
 
                     # use correct beam error shape
                     if beam_error:
@@ -4235,9 +4285,7 @@ class XFaster(object):
 
         return cbl
 
-    def get_model_spectra(
-        self, qb, cbl, delta=True, res=True, cls_noise=None, cond_noise=None
-    ):
+    def get_model_spectra(self, qb, cbl, cls_noise=None, cond_noise=None):
         """
         Compute unbinned model spectra from qb amplitudes and a Cbl matrix.
         Requires pre-loaded bin definitions using ``get_bin_def`` or
@@ -4251,11 +4299,6 @@ class XFaster(object):
             Array of bandpowers for every spectrum bin.
         cbl : dict
             Cbl dict as computed by ``bin_cl_template``.
-        delta : bool
-            If True, evaluate the foreground model at the spectral
-            index offset by qb['delta_beta']
-        res : bool
-            If True, include the residual noise model terms.
         cls_noise : OrderedDict
             If supplied, the noise spectrum is applied to the model spectrum.
         cond_noise : float
@@ -4278,19 +4321,15 @@ class XFaster(object):
         """
         comps = []
 
-        if any([k.startswith("cmb_") for k in qb]):
-            comps = ["cmb"]
+        for comp in self.components:
+            if any([k.startswith(comp + "_") for k in qb]):
+                comps += [comp]
 
         delta_beta = 0.0
         if "delta_beta" in qb:
             # Evaluate fg at spectral index pivot for derivative
             # in Fisher matrix, unless delta is True
-            if delta:
-                delta_beta = qb["delta_beta"][0]
-            comps += ["fg"]
-
-        if res and any([k.startswith("res_") for k in qb]):
-            comps += ["res"]
+            delta_beta = qb["delta_beta"][0]
 
         if cls_noise is not None:
             comps += ["noise"]
@@ -4307,11 +4346,10 @@ class XFaster(object):
 
         specs = []
         for spec in self.specs:
-            if "cmb_{}".format(spec) in cbl:
-                # Don't add entries that won't be filled in later
-                cls["total_{}".format(spec)] = OrderedDict()
-            elif "fg_{}".format(spec) in cbl:
-                cls["total_{}".format(spec)] = OrderedDict()
+            for comp in self.signal_components:
+                if "{}_{}".format(comp, spec) in cbl:
+                    # Don't add entries that won't be filled in later
+                    cls["total_{}".format(spec)] = OrderedDict()
             specs.append(spec)
 
         for comp in comps:
@@ -4335,25 +4373,18 @@ class XFaster(object):
                     tag1, tag2 = self.map_pairs[xname]
 
                     # extract qb's for the component spectrum
-                    if comp == "cmb":
+                    if comp == "cmb" or (comp == "fg" and delta_beta == 0.0):
                         qbs = qb[stag]
                         if spec in ["ee", "bb"]:
                             qbm = qb[mstag]
 
                     elif comp == "fg":
-                        # frequency scaling for foreground model
-                        # I don't remember why delta beta was done this way.
-                        # For likelihood, it makes sense to just use beta_ref+db
-                        freq_scale = st.scale_dust(
-                            self.map_freqs[tag1],
-                            self.map_freqs[tag2],
-                            ref_freq=self.ref_freq,
-                            beta=self.beta_ref,
-                            delta_beta=delta_beta,
-                        )
-                        qbs = freq_scale * qb[stag]
+                        # beta scaling for foreground model
+                        # beta_scale = self.fg_scales[xname][1] ** delta_beta
+                        beta_scale = 1 + self.fg_scales[xname][2] * delta_beta
+                        qbs = beta_scale * qb[stag]
                         if spec in ["ee", "bb"]:
-                            qbm = freq_scale * qb[mstag]
+                            qbm = beta_scale * qb[mstag]
 
                     elif comp == "res":
                         # modify model by previously fit res, including
@@ -4409,7 +4440,7 @@ class XFaster(object):
                         cl1 /= 2.0
 
                     # compute model spectra
-                    if comp in ["cmb", "fg"]:
+                    if comp in self.signal_components:
                         if xname not in cbl[stag]:
                             continue
                         cbl1 = cbl[stag][xname]
@@ -4448,10 +4479,9 @@ class XFaster(object):
                     cls.setdefault(stag, OrderedDict())[xname] = cl1
 
                     # add to total model
-                    if not isinstance(cl1, dict):
-                        ttag = "total_{}".format(spec)
-                        cls[ttag].setdefault(xname, np.zeros_like(cl1))
-                        cls[ttag][xname] += cl1
+                    ttag = "total_{}".format(spec)
+                    cls[ttag].setdefault(xname, np.zeros_like(cl1))
+                    cls[ttag][xname] += cl1
 
         return cls
 
@@ -4473,7 +4503,7 @@ class XFaster(object):
             ``get_masked_data`` for how these are computed.  The input noise is
             similarly either ``cls_noise_null`` or ``cls_noise``.
         do_noise : bool
-            If True, return noise spectra along with data.
+            If True, return noise spectra and debiased spectra along with data.
 
         Returns
         -------
@@ -4481,6 +4511,8 @@ class XFaster(object):
             Dictionary of data cross spectra
         nell : OrderedDict
             Dictionary of noise cross spectra, or None if transfer_run is True.
+        debias : OrderedDict
+            Dictionary of debiased data cross spectra
         """
         # select map pairs
         if map_tag is not None:
@@ -4490,7 +4522,7 @@ class XFaster(object):
         map_pairs = pt.tag_pairs(map_tags)
 
         # select spectra
-        tbeb = "cmb_tb" in self.bin_def
+        tbeb = "tb" in self.specs
         if transfer_run or not tbeb:
             specs = self.specs[:4]
         else:
@@ -4519,12 +4551,14 @@ class XFaster(object):
         if not do_noise:
             return obs
 
-        nell = None
-        debias = None
+        elif transfer_run:
+            return obs, None, None
+
+        nell = OrderedDict()
+        debias = OrderedDict()
+
         # Nulls are debiased by average of S+N sims
-        if self.null_run and not transfer_run and self.cls_sim_null is not None:
-            nell = OrderedDict()
-            debias = OrderedDict()
+        if self.null_run and self.cls_sim_null is not None:
             for spec in specs:
                 nell[spec] = OrderedDict()
                 debias[spec] = OrderedDict()
@@ -4537,9 +4571,7 @@ class XFaster(object):
                         debias[spec][xname] = np.copy(self.cls_sim_null[spec][xname])
 
         # Non-nulls are debiased by average of N sims
-        elif not transfer_run and self.cls_noise is not None:
-            nell = OrderedDict()
-            debias = OrderedDict()
+        elif not self.null_run and self.cls_noise is not None:
             for spec in specs:
                 nell[spec] = OrderedDict()
                 debias[spec] = OrderedDict()
@@ -4551,6 +4583,9 @@ class XFaster(object):
                     else:
                         nell[spec][xname] = np.copy(self.cls_noise[spec][xname])
                     debias[spec][xname] = np.copy(nell[spec][xname])
+
+        else:
+            nell = debias = None
 
         return obs, nell, debias
 
@@ -4613,7 +4648,7 @@ class XFaster(object):
         for stag, wbl1 in wbl.items():
             # compute conversion factors
             qb2cb[stag] = np.zeros((len(wbl1), len(wbl1)))
-            cls_shape = self.cls_shape["fg" if "fg" in stag else stag][: len(ell)]
+            cls_shape = self.cls_shape[stag][: len(ell)]
             v = norm * wbl1 * cls_shape
             bd = self.bin_def[stag]
             bw = self.bin_weights[stag]
@@ -4700,11 +4735,10 @@ class XFaster(object):
         pol_dim = 3 if self.pol else 1
         dim1 = pol_dim * num_maps
 
-        comps = ["cmb"]
-        if "fg_tt" in cbl:
-            comps += ["fg"]
-        if "res_tt" in cbl or "res_ee" in cbl:
-            comps += ["res"]
+        comps = []
+        for comp in self.components:
+            if any([k.startswith(comp + "_") for k in cbl]):
+                comps += [comp]
 
         specs = list(cls_input)
 
@@ -4780,15 +4814,6 @@ class XFaster(object):
                         mspec = "bb" if spec == "ee" else "ee"
                         mix_cbl = cbl[stag + "_mix"][xname]
                         dSdqb[comp][xname][spec][mspec] = mix_cbl
-
-                if comp == "fg":
-                    # add delta beta bin for spectral index
-                    dSdqb.setdefault("delta_beta", OrderedDict()).setdefault(
-                        xname, OrderedDict()
-                    )
-                    for spec in specs:
-                        # this will be filled in in fisher_calc
-                        dSdqb["delta_beta"][xname][spec] = OrderedDict()
 
         return Dmat_obs, Dmat_obs_b, dSdqb, Mmat
 
@@ -4892,7 +4917,6 @@ class XFaster(object):
         well_cond = False
 
         pol_dim = 3 if self.pol else 1
-        do_fg = "fg_tt" in cbl
 
         dkey = "Dmat_obs_b" if likelihood else "Mmat" if windows else "Dmat_obs"
 
@@ -4928,9 +4952,6 @@ class XFaster(object):
         if "delta_beta" in qb:
             delta_beta = qb["delta_beta"][0]
 
-        if not likelihood:
-            dSdqb_mat1_freq = copy.deepcopy(dSdqb_mat1)
-
         if likelihood or windows or not cond_noise:
             well_cond = True
             cond_noise = None
@@ -4940,7 +4961,7 @@ class XFaster(object):
 
         if cls_model is None:
             cls_model = self.get_model_spectra(
-                qb, cbl, delta=True, cls_noise=cls_noise, cond_noise=cond_noise
+                qb, cbl, cls_noise=cls_noise, cond_noise=cond_noise
             )
 
         mkeys = list(cls_model)
@@ -4961,45 +4982,46 @@ class XFaster(object):
         if well_cond:
             Dmat1_mat = pt.dict_to_dmat(Dmat1)
 
-        # Set up dSdqb frequency dependence
-        for xname, (m0, m1) in self.map_pairs.items():
-            # transfer function does not have crosses
-            if xname not in cls_model[mkeys[0]]:
-                continue
+        # Set up dSdqb spectral index dependence
+        if "delta_beta" in qb and not likelihood:
+            # don't make changes to cached matrix
+            dSdqb_mat1 = copy.deepcopy(dSdqb_mat1)
+            dSdqb_mat1["delta_beta"] = OrderedDict()
 
-            if do_fg and not likelihood:
+            for xname in self.map_pairs:
+                # transfer function does not have crosses
+                if xname not in cls_model[mkeys[0]]:
+                    continue
+
+                dSdqb_mat1["delta_beta"][xname] = OrderedDict()
+
                 # Add spectral index dependence
                 # dSdqb now depends on qb (spec index) because
                 # model is non-linear so cannot be precomputed.
 
                 # get foreground at pivot point spectral index
-                # and first derivative
-                freq_scale0, freq_scale_deriv = st.scale_dust(
-                    self.map_freqs[m0],
-                    self.map_freqs[m1],
-                    ref_freq=self.ref_freq,
-                    beta=self.beta_ref,
-                    deriv=True,
-                )
-                freq_scale = freq_scale0 + delta_beta * freq_scale_deriv
-                freq_scale_ratio = freq_scale_deriv / freq_scale
+                _, beta_scale, log_beta_scale = self.fg_scales[xname]
+                # separable beta correction
+                # beta_scale = beta_scale ** delta_beta  # non-linear
+                beta_scale = 1 + log_beta_scale * delta_beta  # linear
+                beta_scale0 = log_beta_scale / beta_scale
 
                 # scale foreground model by frequency scaling adjusted for beta
-                for s1, sdat in dSdqb_mat1_freq["fg"][xname].items():
+                for s1, sdat in dSdqb_mat1["fg"][xname].items():
                     for s2, sdat2 in sdat.items():
-                        dSdqb_mat1_freq["fg"][xname][s1][s2] *= freq_scale
+                        sdat2 *= beta_scale
 
-                # build delta_beta term from frequency scaled model,
-                # divide out frequeny scaling and apply derivative term
-                for s1, sdat in dSdqb_mat1_freq["delta_beta"][xname].items():
-                    sdat[s1] = cls_model["fg_{}".format(s1)][xname] * freq_scale_ratio
+                    # with linearized derivative term, evaluated at input beta
+                    dSdqb_mat1["delta_beta"][xname][s1] = OrderedDict(
+                        {s1: cls_model["fg_{}".format(s1)][xname] * beta_scale0}
+                    )
 
         # Set up Dmat -- if it's not well conditioned, add noise to the
         # diagonal until it is.
         cond_iter = 0
         while not well_cond:
             cls_model = self.get_model_spectra(
-                qb, cbl, delta=True, cls_noise=cls_noise, cond_noise=cond_noise
+                qb, cbl, cls_noise=cls_noise, cond_noise=cond_noise
             )
 
             for xname, (m0, m1) in self.map_pairs.items():
@@ -5050,7 +5072,9 @@ class XFaster(object):
         else:
             if not windows:
                 Dmat_obs = pt.dict_to_dmat(Dmat_obs)
-            dSdqb_mat1_freq = pt.dict_to_dsdqb_mat(dSdqb_mat1_freq, self.bin_def)
+            # select only derivative terms for bins that are iterated
+            bin_def = OrderedDict([(k, v) for k, v in self.bin_def.items() if k in qb])
+            dSdqb_mat1 = pt.dict_to_dsdqb_mat(dSdqb_mat1, bin_def)
 
         # apply ell limits
         if likelihood:
@@ -5066,7 +5090,7 @@ class XFaster(object):
         else:
             if not windows:
                 Dmat_obs = Dmat_obs[..., ell]
-            dSdqb_mat1_freq = dSdqb_mat1_freq[..., ell]
+            dSdqb_mat1 = dSdqb_mat1[..., ell]
         gmat = gmat[..., ell]
 
         lam, R = np.linalg.eigh(Dmat1.swapaxes(0, -1))
@@ -5101,7 +5125,7 @@ class XFaster(object):
             del lam, R
             eye = np.eye(len(gmat))
             mat1 = np.einsum("ij...,jk...->ik...", eye, Dinv)
-            mat2 = np.einsum("klm...,ln...->knm...", dSdqb_mat1_freq, Dinv)
+            mat2 = np.einsum("klm...,ln...->knm...", dSdqb_mat1, Dinv)
             del Dinv
             mat = np.einsum("ik...,knm...->inm...", mat1, mat2)
             del mat1, mat2
@@ -5130,8 +5154,8 @@ class XFaster(object):
         # construct matrices for the qb and fisher terms,
         # and take the trace and sum over ell simultaneously
         if not windows or (windows and inv_fish is None):
-            fisher = np.einsum("iil,ijkl,jiml->km", gmat, mat, dSdqb_mat1_freq) / 2
-            del dSdqb_mat1_freq
+            fisher = np.einsum("iil,ijkl,jiml->km", gmat, mat, dSdqb_mat1) / 2
+            del dSdqb_mat1
         if not windows:
             qb_vec = np.einsum("iil,ijkl,jil->k", gmat, mat, Dmat_obs) / 2.0
             del gmat, mat, Dmat_obs
@@ -5154,7 +5178,7 @@ class XFaster(object):
             # compute window functions for each spectrum
             for k, (left, right) in bin_index.items():
                 comp, spec = k.split("_", 1)
-                if comp not in ["cmb", "fg"]:
+                if comp not in self.signal_components:
                     continue
 
                 # select bins for corresponding spectrum
@@ -5173,7 +5197,7 @@ class XFaster(object):
                     chi_bl[l:r] += w
 
                 # check normalization
-                cls_shape = self.cls_shape["fg" if comp == "fg" else k][: len(norm)]
+                cls_shape = self.cls_shape[k][: len(norm)]
                 self.log(
                     "{} qb window function normalization: {}".format(
                         k, np.sum(wbl1 * norm * chi_bl * cls_shape, axis=-1)
@@ -5405,9 +5429,7 @@ class XFaster(object):
 
             # put qb_new in original dict
             qb = copy.deepcopy(qb_new)
-            cls_model = self.get_model_spectra(
-                qb, cbl, delta=True, cls_noise=nell, cond_noise=None
-            )
+            cls_model = self.get_model_spectra(qb, cbl, cls_noise=nell, cond_noise=None)
 
             if "delta_beta" in qb:
                 # get beta fit and beta error
@@ -5433,7 +5455,6 @@ class XFaster(object):
                     inv_fish=inv_fish,
                     cls_model=cls_model,
                     cbl=cbl,
-                    map_freqs=self.map_freqs,
                     cls_signal=self.cls_signal,
                     cls_noise=self.cls_noise,
                     Dmat_obs=self.Dmat_obs,
@@ -5441,13 +5462,17 @@ class XFaster(object):
                     extra_tag=file_tag,
                 )
 
-                if "fg_tt" in self.bin_def and not transfer_run:
+                if "fg" in self.components and not transfer_run:
                     out.update(
-                        beta_fit=beta_fit,
-                        beta_err=beta_err,
-                        ref_freq=self.ref_freq,
+                        map_freqs=self.map_freqs,
+                        freq_ref=self.freq_ref,
                         beta_ref=self.beta_ref,
                     )
+                    if "delta_beta" in qb:
+                        out.update(
+                            beta_fit=beta_fit,
+                            beta_err=beta_err,
+                        )
 
                 self.save_data(save_name, bp_opts=not transfer_run, **out)
 
@@ -5549,7 +5574,6 @@ class XFaster(object):
             iters=iter_idx,
             success=success,
             map_tags=self.map_tags,
-            map_freqs=self.map_freqs,
             converge_criteria=converge_criteria,
             cond_noise=cond_noise,
             cond_criteria=cond_criteria,
@@ -5558,14 +5582,18 @@ class XFaster(object):
             weighted_bins=self.weighted_bins,
         )
 
-        if "fg_tt" in self.bin_def and not transfer_run:
+        if "fg" in self.components and not transfer_run:
             out.update(
-                delta_beta_prior=delta_beta_prior,
-                beta_fit=beta_fit,
-                beta_err=beta_err,
-                ref_freq=self.ref_freq,
+                map_freqs=self.map_freqs,
+                freq_ref=self.freq_ref,
                 beta_ref=self.beta_ref,
             )
+            if "delta_beta" in qb:
+                out.update(
+                    delta_beta_prior=delta_beta_prior,
+                    beta_fit=beta_fit,
+                    beta_err=beta_err,
+                )
 
         if self.debug:
             out.update(
@@ -5594,7 +5622,7 @@ class XFaster(object):
             self.log("Calculating final Fisher matrix without sample variance.", "info")
             qb_zeroed = copy.deepcopy(qb)
             qb_new_ns = copy.deepcopy(qb)
-            for comp in ["cmb", "fg"]:
+            for comp in self.signal_components:
                 for spec in self.specs:
                     stag = "{}_{}".format(comp, spec)
                     if stag not in qb_zeroed:
@@ -5620,8 +5648,8 @@ class XFaster(object):
                 invfish_nosampvar=inv_fish_ns,
             )
 
-            # compute window functions for CMB bins
-            self.log("Calculating window functions for CMB bins", "info")
+            # compute window functions for signal bins
+            self.log("Calculating signal window functions", "info")
             wbl_qb = self.fisher_calc(
                 qb,
                 cbl,
@@ -5742,26 +5770,26 @@ class XFaster(object):
         fix_bb_transfer=False,
     ):
         """
-        Compute the transfer function from signal simulations created using
-        the same spectrum as the input shape.
+        Compute the transfer function from signal simulations created using the
+        same spectrum as the input shape.
 
-        This raises a ValueError if a negative transfer function amplitude
-        is found.
+        This raises a ValueError if a negative transfer function amplitude is
+        found.
 
         Arguments
         ---------
         converge_criteria : float
-            Maximum fractional change in qb that indicates convergence and
-            stops iteration.
+            Maximum fractional change in qb that indicates convergence and stops
+            iteration.
         iter_max : int
-            Maximum number of iterations to perform.  if this limit is
-            reached, a warning is issued.
+            Maximum number of iterations to perform.  if this limit is reached,
+            a warning is issued.
         save_iters : bool
-            If True, the output data from each Fisher iteration are stored
-            in an individual npz file.
+            If True, the output data from each Fisher iteration are stored in an
+            individual npz file.
         fix_bb_transfer : bool
-            If True, after transfer functions have been calculated, impose
-            the BB xfer is exactly equal to the EE transfer.
+            If True, after transfer functions have been calculated, impose the
+            BB xfer is exactly equal to the EE transfer.
 
         Returns
         -------
@@ -5770,8 +5798,8 @@ class XFaster(object):
 
         Notes
         -----
-        This method is called at the 'transfer' checkpoint, and loads or saves
-        a data dictionary named 'transfer_all' with the following entries:
+        This method is called at the 'transfer' checkpoint, and loads or saves a
+        data dictionary named 'transfer_all' with the following entries:
 
             nbins:
                 number of bins
@@ -5782,8 +5810,8 @@ class XFaster(object):
             transfer:
                 ell-by-ell transfer function for each map and spectrum component
 
-        Additionally the final output of ``fisher_iterate`` is stored
-        in a dictionary called ``transfer_map<idx>`` for each map.
+        Additionally the final output of ``fisher_iterate`` is stored in a
+        dictionary called ``transfer_map<idx>`` for each map.
         """
         transfer_shape = (
             self.num_maps * len(self.specs),
@@ -5811,33 +5839,50 @@ class XFaster(object):
         )
 
         # function for converting qb's to ell-by-ell transfer function
-        def expand_transfer(qb_transfer, bin_def):
-            transfer = OrderedDict()
+        def expand_transfer(qb_transfer, bin_def, check_only=False):
+            if not check_only:
+                transfer = OrderedDict()
             for spec in self.specs:
                 stag = "cmb_{}".format(spec)
-                transfer[spec] = OrderedDict()
+                if stag not in bin_def or stag not in qb_transfer:
+                    raise KeyError(stag)
+                if not check_only:
+                    transfer[spec] = OrderedDict()
                 bd = bin_def[stag]
                 for m0 in self.map_tags:
+                    if m0 not in qb_transfer[stag]:
+                        raise KeyError(m0)
+                    lq = len(qb_transfer[stag][m0])
+                    lb = len(bin_def[stag])
+                    if lq != lb:
+                        raise ValueError(
+                            "Found {} transfer bins for component {} map {}, expected {}".format(
+                                lq, stag, m0, lb
+                            )
+                        )
+                    if check_only:
+                        continue
                     if spec == "bb" and fix_bb_transfer:
-                        transfer[spec][m0] = transfer["ee"][m0]
-                    elif spec in ["tb", "eb"]:
+                        v = transfer["ee"][m0]
+                    elif spec in ["tb", "eb"] and stag not in qb_transfer:
                         speca, specb = [s + s for s in spec]
-                        transfer[spec][m0] = np.sqrt(
-                            np.abs(transfer[speca][m0] * transfer[specb][m0])
-                        )
+                        v = np.sqrt(np.abs(transfer[speca][m0] * transfer[specb][m0]))
                     else:
-                        transfer[spec][m0] = pt.expand_qb(
-                            qb_transfer[stag][m0], bd, self.lmax + 1
-                        )
-            return transfer
+                        v = pt.expand_qb(qb_transfer[stag][m0], bd, self.lmax + 1)
+                    transfer[spec][m0] = v
+            if not check_only:
+                return transfer
 
         if ret is not None:
-            self.qb_transfer = ret["qb_transfer"]
-            if "transfer" in ret:
-                self.transfer = ret["transfer"]
+            try:
+                check_only = ret.get("transfer", None) is not None
+                xfer = expand_transfer(ret["qb_transfer"], ret["bin_def"], check_only)
+            except:
+                ret = None
             else:
-                self.transfer = expand_transfer(ret["qb_transfer"], ret["bin_def"])
-            return self.transfer
+                self.qb_transfer = ret["qb_transfer"]
+                self.transfer = xfer or ret["transfer"]
+                return self.transfer
 
         self.qb_transfer = OrderedDict()
         for spec in self.specs:
@@ -5934,8 +5979,6 @@ class XFaster(object):
         iter_max=200,
         return_qb=False,
         save_iters=False,
-        ref_freq=359.7,
-        beta_ref=1.54,
         delta_beta_prior=None,
         cond_noise=None,
         cond_criteria=None,
@@ -5971,13 +6014,6 @@ class XFaster(object):
         save_iters : bool
             If True, the output data from each Fisher iteration are stored
             in an individual npz file.
-        ref_freq : float
-            In GHz, reference frequency for dust model. Dust bandpowers output
-            will be at this reference frequency.
-        beta_ref : float
-            The spectral index of the dust model. This is a fixed value, with
-            an additive deviation from this value fit for in foreground fitting
-            mode.
         delta_beta_prior : float
             The width of the prior on the additive change from beta_ref. If you
             don't want the code to fit for a spectral index different
@@ -6034,17 +6070,15 @@ class XFaster(object):
         )
 
         # foreground fitting
-        if "fg_tt" in self.bin_def:
-            # reference frequency and spectral index
-            self.ref_freq = ref_freq
-            self.beta_ref = beta_ref
-            # priors on frequency spectral index
-            self.delta_beta_fix = 1.0e-8
+        if "fg" in self.components:
             opts.update(
-                delta_beta_prior=delta_beta_prior,
-                ref_freq=self.ref_freq,
+                freq_ref=self.freq_ref,
                 beta_ref=self.beta_ref,
             )
+            if "delta_beta" in self.bin_def:
+                # priors on frequency spectral index
+                self.delta_beta_fix = 1.0e-8
+                opts.update(delta_beta_prior=delta_beta_prior)
 
         if self.template_cleaned:
             opts.update(template_alpha=self.template_alpha)
@@ -6068,12 +6102,11 @@ class XFaster(object):
 
         self.clear_precalc()
 
-        cbl = self.bin_cl_template(map_tag=map_tag, transfer_run=False)
+        cbl = self.bin_cl_template(map_tag=map_tag)
 
         ret = self.fisher_iterate(
             cbl,
             map_tag,
-            transfer_run=False,
             iter_max=iter_max,
             converge_criteria=converge_criteria,
             save_iters=save_iters,
@@ -6328,11 +6361,6 @@ class XFaster(object):
                     self.bin_def[k] = bd[good]
                     v = qb.pop(k)[good]
                     num_res += len(v)
-
-                    # use average qb res in good range per map
-                    # self.bin_def[k] = np.array([[lmin, lmax + 1]])
-                    # v = np.array([(qb.pop(k)[good]).mean()])
-                    # num_res += 1
                     qb_res[k] = v
             self.nbins_res = num_res
 
@@ -6342,20 +6370,27 @@ class XFaster(object):
             self.log("Computing model spectrum", "debug")
             self.warn("Beam variation not implemented for case of no r fit")
             cbl = self.bin_cl_template(map_tag=map_tag)
-            cls_model = self.get_model_spectra(qb, cbl, delta=True, cls_noise=cls_noise)
+            cls_model = self.get_model_spectra(qb, cbl, cls_noise=cls_noise)
         else:
             qb = copy.deepcopy(qb)
             for spec in self.specs:
-                stags = ["cmb_{}".format(spec), "fg_{}".format(spec)]
+                stags = ["{}_{}".format(c, spec) for c in self.signal_components]
                 for stag in stags:
                     if stag not in qb:
                         continue
                     qb[stag] = np.ones_like(qb[stag])
+            qb_cmb = OrderedDict(
+                [(k, v) for k, v in qb.items() if k.startswith("cmb_")]
+            )
 
             self.log("Computing r model spectrum", "debug")
             cls_shape_scalar = self.get_signal_shape(
                 r=1.0, save=False, component="scalar"
             )
+            if "fg" in self.signal_components:
+                cls_shape_scalar.update(
+                    {k: cls for k, cls in self.cls_shape.items() if k.startswith("fg_")}
+                )
 
             cls_shape_tensor = self.get_signal_shape(
                 r=1.0, save=False, component="tensor"
@@ -6364,26 +6399,20 @@ class XFaster(object):
             # load tensor and scalar terms separately
             cbl_scalar = self.bin_cl_template(cls_shape_scalar, map_tag)
             cls_model_scalar = self.get_model_spectra(
-                qb, cbl_scalar, delta=True, cls_noise=cls_noise
+                qb, cbl_scalar, cls_noise=cls_noise
             )
             cbl_tensor = self.bin_cl_template(cls_shape_tensor, map_tag)
-            cls_model_tensor = self.get_model_spectra(
-                qb, cbl_tensor, delta=False, res=False
-            )
+            cls_model_tensor = self.get_model_spectra(qb_cmb, cbl_tensor)
             if beam_prior is not None:
                 # load beam error term for tensor and scalar
                 cbl_scalar_beam = self.bin_cl_template(
                     cls_shape_scalar, map_tag, beam_error=True
                 )
-                cls_mod_scal_beam = self.get_model_spectra(
-                    qb, cbl_scalar_beam, delta=True, res=False
-                )
+                cls_mod_scal_beam = self.get_model_spectra(qb, cbl_scalar_beam)
                 cbl_tensor_beam = self.bin_cl_template(
                     cls_shape_tensor, map_tag, beam_error=True
                 )
-                cls_mod_tens_beam = self.get_model_spectra(
-                    qb, cbl_tensor_beam, delta=False, res=False
-                )
+                cls_mod_tens_beam = self.get_model_spectra(qb_cmb, cbl_tensor_beam)
 
             cbl = copy.deepcopy(cbl_scalar)
             cls_model = copy.deepcopy(cls_model_scalar)
@@ -6483,6 +6512,7 @@ class XFaster(object):
                     beam_coeffs[xname] = d
 
             # compute new signal shape by scaling tensor component by r
+            # XXX handle beam fg terms here too
             if r is not None:
                 for stag, d in cls_model0.items():
                     comp, spec = stag.split("_", 1)

--- a/xfaster/xfaster_exec.py
+++ b/xfaster/xfaster_exec.py
@@ -59,6 +59,7 @@ def xfaster_run(
     bin_width_res=25,
     res_specs=None,
     foreground_fit=False,
+    beta_fit=False,
     bin_width_fg=30,
     # data options
     template_alpha_tags=None,
@@ -96,8 +97,9 @@ def xfaster_run(
     qb_file_sim=None,
     signal_spec=None,
     signal_transfer_spec=None,
+    foreground_spec=None,
     model_r=None,
-    ref_freq=359.7,
+    freq_ref=359.7,
     beta_ref=1.54,
     delta_beta_prior=0.5,
     like_profiles=False,
@@ -242,6 +244,9 @@ def xfaster_run(
         polarized maps, or TT for unpolarized maps.
     foreground_fit : bool
         Include foreground residuals in the estimator.
+    beta_fit : bool
+        If True, include a fit for ``delta_beta`` in the estimator.  Otherwise,
+        only fit for foreground amplitudes.
     bin_width_fg : int or array_like of 6 ints
         Width of each ell bin for each of the six output foreground spectra
         (TT, EE, BB, TE, EB, TB).  EE/BB bins should be the same
@@ -344,17 +349,22 @@ def xfaster_run(
         to correct the noise ensemble by an appropriate set of residual ``qb``
         values.
     signal_spec : str
-        The spectrum data file to use for estimating bandpowers.  If not
-        supplied, will search for ``spec_signal_<signal_type>.dat`` in the signal
-        sim directory.
+        The spectrum data file to use for estimating signal component
+        bandpowers.  If not supplied, will search for
+        ``spec_signal_<signal_type>.dat`` in the signal sim directory.
     signal_transfer_spec : str
-        The spectrum data file used to generate signal sims.  If not
-        supplied, will search for ``spec_signal_<signal_type>.dat`` in the
-        transfer signal sim directory. Used for computing transfer functions.
+        The spectrum data file used to generate signal sims for computing the
+        signal transfer function.  If not supplied, will search for
+        ``spec_signal_<signal_transfer_type>.dat`` in the transfer signal sim
+        directory.
+    foreground_spec : string
+        The spectrum data file to use for estimating foreground component
+        bandpowers.  If not supplied, use a simple power law model for dust
+        foregrounds.
     model_r : float
         The ``r`` value to use to compute a spectrum for estimating bandpowers.
         Overrides ``signal_spec``.
-    ref_freq : float
+    freq_ref : float
         In GHz, reference frequency for dust model. Dust bandpowers output
         will be at this reference frequency.
     beta_ref : float
@@ -532,6 +542,7 @@ def xfaster_run(
         res_specs=res_specs,
         bin_width_res=bin_width_res,
         foreground_fit=foreground_fit,
+        beta_fit=beta_fit,
         bin_width_fg=bin_width_fg,
     )
     config_vars.update(bin_opts, "Binning Options")
@@ -573,8 +584,9 @@ def xfaster_run(
         fix_bb_transfer=fix_bb_transfer,
         signal_spec=signal_spec,
         signal_transfer_spec=signal_transfer_spec,
+        foreground_spec=foreground_spec,
         model_r=model_r,
-        ref_freq=ref_freq,
+        freq_ref=freq_ref,
         beta_ref=beta_ref,
         delta_beta_prior=delta_beta_prior,
         cond_noise=cond_noise,
@@ -593,7 +605,10 @@ def xfaster_run(
     spec_opts.pop("multi_map")
     spec_opts.pop("signal_spec")
     spec_opts.pop("signal_transfer_spec")
+    spec_opts.pop("foreground_spec")
     spec_opts.pop("model_r")
+    spec_opts.pop("freq_ref")
+    spec_opts.pop("beta_ref")
     spec_opts.pop("qb_file")
     bandpwr_opts = spec_opts.copy()
     bandpwr_opts.pop("fix_bb_transfer")
@@ -602,8 +617,6 @@ def xfaster_run(
     transfer_opts = spec_opts.copy()
     transfer_opts.pop("cond_noise")
     transfer_opts.pop("cond_criteria")
-    transfer_opts.pop("ref_freq")
-    transfer_opts.pop("beta_ref")
     transfer_opts.pop("delta_beta_prior")
     transfer_opts.pop("null_first_cmb")
     transfer_opts.pop("return_cls")
@@ -687,7 +700,13 @@ def xfaster_run(
         X.get_signal_shape(flat=True)
     else:
         X.log("Loading spectrum shape for bandpowers...", "notice")
-        X.get_signal_shape(filename=signal_spec, r=model_r)
+        X.get_signal_shape(
+            filename=signal_spec,
+            r=model_r,
+            filename_fg=foreground_spec,
+            freq_ref=freq_ref,
+            beta_ref=beta_ref,
+        )
 
     if multi_map:
         X.log("Computing multi-map bandpowers...", "notice")
@@ -997,6 +1016,7 @@ def xfaster_parse(args=None, test=False):
             metavar="SPEC",
         )
         add_arg(G, "foreground_fit")
+        add_arg(G, "beta_fit")
         add_arg(G, "bin_width_fg", nargs="+")
 
         # data options
@@ -1049,7 +1069,8 @@ def xfaster_parse(args=None, test=False):
         add_arg(E, "signal_spec")
         add_arg(E, "model_r")
         add_arg(G, "signal_transfer_spec")
-        add_arg(G, "ref_freq")
+        add_arg(G, "foreground_spec")
+        add_arg(G, "freq_ref", argtype=float)
         add_arg(G, "beta_ref", argtype=float)
         add_arg(G, "delta_beta_prior", argtype=float)
         add_arg(G, "like_profiles")


### PR DESCRIPTION
This PR cleans up the foreground fitting components to simplify integration of new features.  Changes include:

* Addition of a foreground ensemble and simulated data with a foreground component in the `make_example_maps.py` script
* An example script for enabling the foreground fitting options, `xfaster_example_fg.py`
* Unified handling of the input shape spectrum and foreground frequency scaling terms
* Option to enable or disable fitting for `beta` with the `beta_fit` parameter